### PR TITLE
Fix postgres provider not using password [Close #4]

### DIFF
--- a/src/Databases/PostgresqlDatabase.php
+++ b/src/Databases/PostgresqlDatabase.php
@@ -35,7 +35,8 @@ class PostgresqlDatabase implements Database
      */
     public function getDumpCommandLine($outputPath)
     {
-        return sprintf('pg_dump --host=%s --port=%s --username=%s %s -f %s',
+        return sprintf('PGPASSWORD=%s pg_dump --host=%s --port=%s --username=%s %s -f %s',
+            escapeshellarg($this->config['pass']),
             escapeshellarg($this->config['host']),
             escapeshellarg($this->config['port']),
             escapeshellarg($this->config['user']),
@@ -50,7 +51,8 @@ class PostgresqlDatabase implements Database
      */
     public function getRestoreCommandLine($inputPath)
     {
-        return sprintf('psql --host=%s --port=%s --user=%s %s -f %s',
+        return sprintf('PGPASSWORD=%s psql --host=%s --port=%s --user=%s %s -f %s',
+            escapeshellarg($this->config['pass']),
             escapeshellarg($this->config['host']),
             escapeshellarg($this->config['port']),
             escapeshellarg($this->config['user']),

--- a/tests/unit/Databases/PostgresqlDatabaseTest.php
+++ b/tests/unit/Databases/PostgresqlDatabaseTest.php
@@ -35,7 +35,7 @@ class PostgresqlDatabaseTest extends PHPUnit_Framework_TestCase
         $config = Config::fromPhpFile('tests/unit/config/database.php');
         $postgres = $this->getDatabase();
         $postgres->setConfig($config->get('production'));
-        $this->assertEquals("pg_dump --host='foo' --port='3306' --username='bar' 'test' -f 'outputPath'", $postgres->getDumpCommandLine('outputPath'));
+        $this->assertEquals("PGPASSWORD='baz' pg_dump --host='foo' --port='3306' --username='bar' 'test' -f 'outputPath'", $postgres->getDumpCommandLine('outputPath'));
     }
 
     public function test_get_restore_command()
@@ -43,7 +43,7 @@ class PostgresqlDatabaseTest extends PHPUnit_Framework_TestCase
         $config = Config::fromPhpFile('tests/unit/config/database.php');
         $postgres = $this->getDatabase();
         $postgres->setConfig($config->get('production'));
-        $this->assertEquals("psql --host='foo' --port='3306' --user='bar' 'test' -f 'outputPath'", $postgres->getRestoreCommandLine('outputPath'));
+        $this->assertEquals("PGPASSWORD='baz' psql --host='foo' --port='3306' --user='bar' 'test' -f 'outputPath'", $postgres->getRestoreCommandLine('outputPath'));
     }
 
     /**


### PR DESCRIPTION
This patch introduces a slight bc break, might break existing users scripts if they expect the interactive prompt, but it should not really be an issue.
