### PR TITLE
Removing the process timeout

### DIFF
--- a/src/Manager.php
+++ b/src/Manager.php
@@ -72,6 +72,6 @@ class Manager
      */
     protected function getShellProcessor()
     {
-        return new ShellProcessor(new Process(''));
+        return new ShellProcessor(new Process('', null, null, null, null));
     }
 } 


### PR DESCRIPTION
The 60 second default timeout interferes with long running backups. Setting the timeout to `null`, as in this PR, disables it. This making large backups possible.
