### PR TITLE
set aws-sdk as minimum version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": ">=5.4.0",
         "symfony/process": "2.*",
-        "aws/aws-sdk-php": "2.4.*",
+        "aws/aws-sdk-php": "~2.4",
         "league/flysystem": ">=0.3.1"
     },
     "require-dev": {


### PR DESCRIPTION
This change will set the minimum version of the amazon-sdk-php to 2.4. (Exactly matching flysystem's)

This will allow users to use a newer version of the sdk (any version where 2.4 <= version < 3.0). There should not be any backwards incompatibility.

References: https://getcomposer.org/doc/01-basic-usage.md#next-significant-release-tilde-operator-
