### PR TITLE
Fix bug with file exists error for local

### DIFF
--- a/src/Procedures/Procedure.php
+++ b/src/Procedures/Procedure.php
@@ -54,6 +54,10 @@ abstract class Procedure
         if (is_null($filename)) {
             $filename = uniqid();
         }
+
+        // Make sure the filename is definitely unique.
+        $filename = rand(1, 100) . $filename;
+
         return sprintf('%s/%s', $this->getRootPath($name), $filename);
     }
 


### PR DESCRIPTION
This fixes #35.

The only thing about this which I'm not 100% will work for all compressions is the file extension. We need the file extension for compressors like gzip because otherwise we get the following error:

```
BigName\BackupManager\ShellProcessing\ShellProcessFailed: gzip: .../5412f7b8f3682: unknown suffix -- ignored
```

This is because the uuid name for the working file doesn't has an extension.
