### PR TITLE
Fix mysql commandline on Windows.

### DIFF
--- a/spec/Databases/MysqlDatabaseSpec.php
+++ b/spec/Databases/MysqlDatabaseSpec.php
@@ -33,7 +33,7 @@ class MysqlDatabaseSpec extends ObjectBehavior
     function it_should_generate_a_valid_database_restore_command()
     {
         $this->configure();
-        $this->getRestoreCommandLine('outputPath')->shouldBe("mysql --host='foo' --port='3306' --user='bar' --password='baz' 'test' -e \"source outputPath;\"");
+        $this->getRestoreCommandLine('outputPath')->shouldBe("mysql --host='foo' --port='3306' --user='bar' --password='baz' 'test' -e \"source outputPath\"");
     }
 
     private function configure()

--- a/src/Databases/MysqlDatabase.php
+++ b/src/Databases/MysqlDatabase.php
@@ -51,7 +51,7 @@ class MysqlDatabase implements Database
      */
     public function getRestoreCommandLine($inputPath)
     {
-        return sprintf('mysql --host=%s --port=%s --user=%s --password=%s %s -e "source %s;"',
+        return sprintf('mysql --host=%s --port=%s --user=%s --password=%s %s -e "source %s"',
             escapeshellarg($this->config['host']),
             escapeshellarg($this->config['port']),
             escapeshellarg($this->config['user']),


### PR DESCRIPTION
On Windows, I get the following error:
> Fatal error: Uncaught exception 'BigName\BackupManager\ShellProcessing\ShellProcessFailed' with message ' in vendor\heybigname\backup-manager\src\ShellProcessing\ShellProcessor.php on line 38
>
> BigName\BackupManager\ShellProcessing\ShellProcessFailed: Warning: Using a password on the command line interface can be insecure.
ERROR at line 1: Unknown command '\U'.
 in vendor\heybigname\backup-manager\src\ShellProcessing\ShellProcessor.php on line 38

This PR fixes the issue.