### PR TITLE
Update aws-sdk-php requirement to v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
   "require": {
     "php": ">=5.4.0",
     "symfony/process": "2.*",
-    "aws/aws-sdk-php": "~2.4",
+    "aws/aws-sdk-php": "~3.0",
     "league/flysystem": "~1.0"
   },
   "require-dev": {


### PR DESCRIPTION
Still requires aws-sdk-php v2