### PR TITLE
Speed up travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: php
+sudo: false
 php:
   - "5.4"
 install:
-  - composer self-update
   - composer install --dev --no-scripts --prefer-source --no-interaction
 script: bin/phpspec run -fpretty -v
 after_script: bin/coveralls -v


### PR DESCRIPTION
According to http://docs.travis-ci.com/user/workers/container-based-infrastructure/ you should use `sudo: false` nowadays to use the container based infrastructure which is a lot faster ([and at the moment the old legacy systems do not work at all](https://travis-ci.org/backup-manager/backup-manager/builds/67504923)).