### PR TITLE
Fixed incorrect PHP requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ $manager->makeRestore()->run('s3', 'test/backup.sql.gz', 'development', 'gzip');
 
 ### Requirements
 
-- PHP 5.5
+- PHP 5.4
 - MySQL support requires `mysqldump` and `mysql` command-line binaries
 - PostgreSQL support requires `pg_dump` and `psql` command-line binaries
 - Gzip support requires `gzip` and `gunzip` command-line binaries


### PR DESCRIPTION
This project requires PHP 5.4.0+ but not 5.5+. It correctly works on 5.4 and `composer.json` contains `>=5.4.0`