### PR TITLE
Allow exporting database dump to multiple locations

### DIFF
--- a/examples/standalone/backup.php
+++ b/examples/standalone/backup.php
@@ -1,4 +1,11 @@
 <?php
 
+use BackupManager\Filesystems\Destination;
+
 $manager = require 'bootstrap.php';
-$manager->makeBackup()->run('development', 's3', 'test/backup.sql', 'gzip');
+$manager
+    ->makeBackup()
+    ->run('development', [
+        new Destination('local', 'test/backup.sql'),
+        new Destination('s3', 'test/dump.sql')
+    ], 'gzip');

--- a/src/Filesystems/Destination.php
+++ b/src/Filesystems/Destination.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace BackupManager\Filesystems;
+
+final class Destination
+{
+    /** @var string */
+    private $destination_filesystem;
+
+    /** @var string */
+    private $destination_path;
+
+    /**
+     * @param string $a_destination_filesystem
+     * @param string $a_destination_path
+     */
+    public function __construct($a_destination_filesystem, $a_destination_path) {
+        $this->destination_filesystem = $a_destination_filesystem;
+        $this->destination_path = $a_destination_path;
+    }
+
+    /**
+     * @return string
+     */
+    public function destinationFilesystem() {
+        return $this->destination_filesystem;
+    }
+
+    /**
+     * @return string
+     */
+    public function destinationPath() {
+        return $this->destination_path;
+    }
+}

--- a/src/Procedures/BackupProcedure.php
+++ b/src/Procedures/BackupProcedure.php
@@ -43,24 +43,51 @@ class BackupProcedure extends Procedure {
         $this->execute();
     }
 
+    /**
+     * @param string $database
+     *
+     * @return void
+     */
     public function setDatabase($database) {
         $this->backup_database = $database;
     }
 
+    /**
+     * @param string $destination
+     *
+     * @return void
+     */
     public function addDestinationFilesystem($destination) {
         if (!array_search($destination, $this->backup_destination_filesystems)) {
             $this->backup_destination_filesystems[] = $destination;
         }
     }
 
+    /**
+     * @param string $destination_path
+     *
+     * @return void
+     */
     public function setDestinationPath($destination_path) {
         $this->backup_destination_path = $destination_path;
     }
 
+    /**
+     * @param string $compression
+     *
+     * @return void
+     */
     public function setCompression($compression) {
         $this->backup_compression = $compression;
     }
 
+    /**
+     * @return void
+     *
+     * @throws \BackupManager\Compressors\CompressorTypeNotSupported
+     * @throws \BackupManager\Databases\DatabaseTypeNotSupported
+     * @throws \BackupManager\Filesystems\FilesystemTypeNotSupported
+     */
     public function execute(){
         $this->sequence = new Sequence();
 

--- a/src/Procedures/BackupProcedure.php
+++ b/src/Procedures/BackupProcedure.php
@@ -4,107 +4,37 @@ use BackupManager\Tasks;
 
 /**
  * Class BackupProcedure
- *
  * @package BackupManager\Procedures
  */
 class BackupProcedure extends Procedure {
-    /** @var Sequence */
-    private $sequence;
-
-    /** @var string */
-    private $backup_database;
-
-    /** @var array */
-    private $backup_destination_filesystems = [];
-
-    /** @var string */
-    private $backup_destination_path;
-
-    /** @var string */
-    private $backup_compression;
 
     /**
      * @param string $database
-     * @param string $destination
-     * @param string $destinationPath
+     * @param \BackupManager\Filesystems\Destination[] $destinations
      * @param string $compression
-     *
      * @throws \BackupManager\Filesystems\FilesystemTypeNotSupported
      * @throws \BackupManager\Config\ConfigFieldNotFound
      * @throws \BackupManager\Compressors\CompressorTypeNotSupported
      * @throws \BackupManager\Databases\DatabaseTypeNotSupported
      * @throws \BackupManager\Config\ConfigNotFoundForConnection
      */
-    public function run($database, $destination, $destinationPath, $compression) {
-        $this->setDatabase($database);
-        $this->addDestinationFilesystem($destination);
-        $this->setDestinationPath($destinationPath);
-        $this->setCompression($compression);
-        $this->execute();
-    }
-
-    /**
-     * @param string $database
-     *
-     * @return void
-     */
-    public function setDatabase($database) {
-        $this->backup_database = $database;
-    }
-
-    /**
-     * @param string $destination
-     *
-     * @return void
-     */
-    public function addDestinationFilesystem($destination) {
-        if (!array_search($destination, $this->backup_destination_filesystems)) {
-            $this->backup_destination_filesystems[] = $destination;
-        }
-    }
-
-    /**
-     * @param string $destination_path
-     *
-     * @return void
-     */
-    public function setDestinationPath($destination_path) {
-        $this->backup_destination_path = $destination_path;
-    }
-
-    /**
-     * @param string $compression
-     *
-     * @return void
-     */
-    public function setCompression($compression) {
-        $this->backup_compression = $compression;
-    }
-
-    /**
-     * @return void
-     *
-     * @throws \BackupManager\Compressors\CompressorTypeNotSupported
-     * @throws \BackupManager\Databases\DatabaseTypeNotSupported
-     * @throws \BackupManager\Filesystems\FilesystemTypeNotSupported
-     */
-    public function execute(){
-        $this->sequence = new Sequence();
+    public function run($database, array $destinations, $compression) {
+        $sequence = new Sequence;
 
         // begin the life of a new working file
         $localFilesystem = $this->filesystems->get('local');
-        $workingFile     = $this->getWorkingFile('local');
+        $workingFile = $this->getWorkingFile('local');
 
         // dump the database
-        $this->sequence->add(new Tasks\Database\DumpDatabase(
-            $this->databases->get($this->backup_database),
+        $sequence->add(new Tasks\Database\DumpDatabase(
+            $this->databases->get($database),
             $workingFile,
             $this->shellProcessor
         ));
 
         // archive the dump
-        $compressor = $this->compressors->get($this->backup_compression);
-        $this->sequence->add(new Tasks\Compression\CompressFile(
+        $compressor = $this->compressors->get($compression);
+        $sequence->add(new Tasks\Compression\CompressFile(
             $compressor,
             $workingFile,
             $this->shellProcessor
@@ -112,18 +42,20 @@ class BackupProcedure extends Procedure {
         $workingFile = $compressor->getCompressedPath($workingFile);
 
         // upload the archive
-        foreach ($this->backup_destination_filesystems as $destination) {
-            $this->sequence->add(new Tasks\Storage\TransferFile(
+        foreach ($destinations as $destination) {
+            $sequence->add(new Tasks\Storage\TransferFile(
                 $localFilesystem, basename($workingFile),
-                $this->filesystems->get($destination), $compressor->getCompressedPath($this->backup_destination_path)));
+                $this->filesystems->get($destination->destinationFilesystem()),
+                $compressor->getCompressedPath($destination->destinationPath())
+            ));
         }
 
         // cleanup the local archive
-        $this->sequence->add(new Tasks\Storage\DeleteFile(
+        $sequence->add(new Tasks\Storage\DeleteFile(
             $localFilesystem,
             basename($workingFile)
         ));
 
-        $this->sequence->execute();
+        $sequence->execute();
     }
 }


### PR DESCRIPTION
Hi,

I've made some modifications to `BackupProcedure` in order to allow exporting database dump to multiple locations. In our case, we store locally last 10 database dumps for easy and fast restoring, and upload to remote S3 as persistent backup. With the original implementation, we were forced to execute the database dump twice to upload to both locations.

With this changes, following the example you include in the source code, you can export to a single location using the same `run` method, or using `execute()` in the following way:

```php
$manager = require 'bootstrap.php';
$processor = $manager->makeBackup();
$processor->addDestinationFileSystem('local');
$processor->setDatabase('database');
$processor->setDestinationPath('dump.sql');
$processor->setCompression('gzip');
$processor->execute();
```

For exporting to local filesystem and Amazon S3 simultaneously, for instance:

```php
$manager = require 'bootstrap.php';
$processor = $manager->makeBackup();
$processor->addDestinationFileSystem('local');
$processor->addDestinationFileSystem('s3');
$processor->setDatabase('database');
$processor->setDestinationPath('dump.sql');
$processor->setCompression('gzip');
$processor->execute();
```

I hope you'll find this changes useful too.

Best regards and congratulations for this great piece of work!