### PR TITLE
Setting gunzip to gzip -d to ensure max compatibility

### DIFF
--- a/spec/Compressors/GzipCompressorSpec.php
+++ b/spec/Compressors/GzipCompressorSpec.php
@@ -28,9 +28,9 @@ class GzipCompressorSpec extends ObjectBehavior {
     }
 
     function it_should_generate_valid_decompression_commands() {
-        $this->getDecompressCommandLine('foo')->shouldBe("gunzip 'foo'");
-        $this->getDecompressCommandLine('../foo.gz')->shouldBe("gunzip '../foo.gz'");
-        $this->getDecompressCommandLine('../foo.sql.gz')->shouldBe("gunzip '../foo.sql.gz'");
+        $this->getDecompressCommandLine('foo')->shouldBe("gzip -d 'foo'");
+        $this->getDecompressCommandLine('../foo.gz')->shouldBe("gzip -d '../foo.gz'");
+        $this->getDecompressCommandLine('../foo.sql.gz')->shouldBe("gzip -d '../foo.sql.gz'");
     }
 
     function it_should_generate_compressed_paths_from_filenames() {

--- a/src/Compressors/GzipCompressor.php
+++ b/src/Compressors/GzipCompressor.php
@@ -27,7 +27,7 @@ class GzipCompressor extends Compressor {
      * @return string
      */
     public function getDecompressCommandLine($outputPath) {
-        return 'gunzip ' . escapeshellarg($outputPath);
+        return 'gzip -d ' . escapeshellarg($outputPath);
     }
 
     /**


### PR DESCRIPTION
Changing the command line so that people with only the gzip command can still do a restore