### PR TITLE
Add single transaction flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ This package is actively being developed and we would like to get feedback to im
     'user' => 'root',
     'pass' => 'password',
     'database' => 'test',
+    // If singleTransaction is set to true, the --single-transcation flag will be set.
+    // This is useful on transactional databases like InnoDB.
+    // http://dev.mysql.com/doc/refman/5.7/en/mysqldump.html#option_mysqldump_single-transaction
+    'singleTransaction' => false
 ],
 'production' => [
     'type' => 'postgresql',

--- a/config/database.php
+++ b/config/database.php
@@ -8,6 +8,7 @@ return [
         'user' => 'root',
         'pass' => 'password',
         'database' => 'test',
+        'singleTransaction' => false
     ],
     'production' => [
         'type' => 'postgresql',

--- a/examples/standalone/config/database.php
+++ b/examples/standalone/config/database.php
@@ -8,6 +8,7 @@ return [
         'user' => 'root',
         'pass' => 'password',
         'database' => 'test',
+        'singleTransaction' => false
     ],
     'production' => [
         'type' => 'postgresql',

--- a/spec/Databases/DatabaseProviderSpec.php
+++ b/spec/Databases/DatabaseProviderSpec.php
@@ -28,6 +28,6 @@ class DatabaseProviderSpec extends ObjectBehavior {
     }
 
     function it_should_provide_a_list_of_available_databases() {
-        $this->getAvailableProviders()->shouldBe(['development', 'production', 'unsupported', 'null']);
+        $this->getAvailableProviders()->shouldBe(['development', 'developmentSingleTrans', 'production', 'unsupported', 'null']);
     }
 }

--- a/spec/Databases/MysqlDatabaseSpec.php
+++ b/spec/Databases/MysqlDatabaseSpec.php
@@ -24,7 +24,7 @@ class MysqlDatabaseSpec extends ObjectBehavior {
 
     function it_should_generate_a_valid_database_dump_command() {
         $this->configure();
-        $this->getDumpCommandLine('outputPath')->shouldBe("mysqldump --routines --host='foo' --port='3306' --user='bar' --password='baz' 'test' > 'outputPath'");
+        $this->getDumpCommandLine('outputPath')->shouldBe("mysqldump --routines  --host='foo' --port='3306' --user='bar' --password='baz' 'test' > 'outputPath'");
     }
 
     function it_should_generate_a_valid_database_dump_command_with_single_transaction() {

--- a/spec/Databases/MysqlDatabaseSpec.php
+++ b/spec/Databases/MysqlDatabaseSpec.php
@@ -27,13 +27,18 @@ class MysqlDatabaseSpec extends ObjectBehavior {
         $this->getDumpCommandLine('outputPath')->shouldBe("mysqldump --routines --host='foo' --port='3306' --user='bar' --password='baz' 'test' > 'outputPath'");
     }
 
+    function it_should_generate_a_valid_database_dump_command_with_single_transaction() {
+        $this->configure('developmentSingleTrans');
+        $this->getDumpCommandLine('outputPath')->shouldBe("mysqldump --routines --single-transaction --host='foo' --port='3306' --user='bar' --password='baz' 'test' > 'outputPath'");
+    }
+
     function it_should_generate_a_valid_database_restore_command() {
         $this->configure();
         $this->getRestoreCommandLine('outputPath')->shouldBe("mysql --host='foo' --port='3306' --user='bar' --password='baz' 'test' -e \"source outputPath\"");
     }
 
-    private function configure() {
+    private function configure($db = 'development') {
         $config = Config::fromPhpFile('spec/configs/database.php');
-        $this->setConfig($config->get('development'));
+        $this->setConfig($config->get($db));
     }
 }

--- a/spec/configs/database.php
+++ b/spec/configs/database.php
@@ -9,6 +9,15 @@ return [
         'pass'     => 'baz',
         'database' => 'test',
     ],
+    'developmentSingleTrans' => [
+        'type'     => 'mysql',
+        'host'     => 'foo',
+        'port'     => '3306',
+        'user'     => 'bar',
+        'pass'     => 'baz',
+        'database' => 'test',
+        'singleTransaction' => true
+    ],
     'production'  => [
         'type'     => 'postgresql',
         'host'     => 'foo',

--- a/src/Databases/MysqlDatabase.php
+++ b/src/Databases/MysqlDatabase.php
@@ -30,7 +30,13 @@ class MysqlDatabase implements Database {
      * @return string
      */
     public function getDumpCommandLine($outputPath) {
-        return sprintf('mysqldump --routines --host=%s --port=%s --user=%s --password=%s %s > %s',
+    	$extras = [];
+    	if (array_key_exists('singleTransaction', $this->config) && $this->config['singleTransaction'] === true) {
+    		$extras[] = '--single-transaction';
+    	}
+    	$extra = count($extras) > 0 ? ' '. implode(' ', $extras) : '';
+    	$command = 'mysqldump --routines'.$extra.' --host=%s --port=%s --user=%s --password=%s %s > %s';
+        return sprintf($command,
             escapeshellarg($this->config['host']),
             escapeshellarg($this->config['port']),
             escapeshellarg($this->config['user']),

--- a/src/Databases/MysqlDatabase.php
+++ b/src/Databases/MysqlDatabase.php
@@ -34,8 +34,7 @@ class MysqlDatabase implements Database {
     	if (array_key_exists('singleTransaction', $this->config) && $this->config['singleTransaction'] === true) {
     		$extras[] = '--single-transaction';
     	}
-    	$extra = count($extras) > 0 ? ' '. implode(' ', $extras) : '';
-    	$command = 'mysqldump --routines'.$extra.' --host=%s --port=%s --user=%s --password=%s %s > %s';
+    	$command = 'mysqldump --routines '.implode(' ', $extras).' --host=%s --port=%s --user=%s --password=%s %s > %s';
         return sprintf($command,
             escapeshellarg($this->config['host']),
             escapeshellarg($this->config['port']),


### PR DESCRIPTION
This adds an option to use the single transaction flag for mysqldump rather than the default lock tables.

http://dev.mysql.com/doc/refman/5.7/en/mysqldump.html#option_mysqldump_single-transaction
