### PR TITLE
Add --ignore-table support for mysql dumps

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -8,7 +8,8 @@ return [
         'user' => 'root',
         'pass' => 'password',
         'database' => 'test',
-        'singleTransaction' => false
+        'singleTransaction' => false,
+        'ignoreTables' => [],
     ],
     'production' => [
         'type' => 'postgresql',

--- a/src/Databases/MysqlDatabase.php
+++ b/src/Databases/MysqlDatabase.php
@@ -34,6 +34,13 @@ class MysqlDatabase implements Database {
     	if (array_key_exists('singleTransaction', $this->config) && $this->config['singleTransaction'] === true) {
     		$extras[] = '--single-transaction';
     	}
+        if (array_key_exists('ignoreTables', $this->config) && is_array($this->config['ignoreTables']) && count($this->config['ignoreTables'])) {
+    	    $db = $this->config['database'];
+    	    $ignoreTables = implode(',', array_map(function($table) use ($db) {
+                return $db.'.'.$table;
+            }, $this->config['ignoreTables']));
+            $extras[] = '--ignore-table='.$ignoreTables;
+        }
     	$command = 'mysqldump --routines '.implode(' ', $extras).' --host=%s --port=%s --user=%s --password=%s %s > %s';
         return sprintf($command,
             escapeshellarg($this->config['host']),

--- a/src/Databases/MysqlDatabase.php
+++ b/src/Databases/MysqlDatabase.php
@@ -34,12 +34,8 @@ class MysqlDatabase implements Database {
     	if (array_key_exists('singleTransaction', $this->config) && $this->config['singleTransaction'] === true) {
     		$extras[] = '--single-transaction';
     	}
-        if (array_key_exists('ignoreTables', $this->config) && is_array($this->config['ignoreTables']) && count($this->config['ignoreTables'])) {
-    	    $db = $this->config['database'];
-    	    $ignoreTables = implode(',', array_map(function($table) use ($db) {
-                return $db.'.'.$table;
-            }, $this->config['ignoreTables']));
-            $extras[] = '--ignore-table='.$ignoreTables;
+        if (array_key_exists('ignoreTables', $this->config)) {
+            $extras[] = $this->getIgnoreTableParameter();
         }
     	$command = 'mysqldump --routines '.implode(' ', $extras).' --host=%s --port=%s --user=%s --password=%s %s > %s';
         return sprintf($command,
@@ -64,6 +60,25 @@ class MysqlDatabase implements Database {
             escapeshellarg($this->config['pass']),
             escapeshellarg($this->config['database']),
             $inputPath
+        );
+    }
+
+    /**
+     * @return string
+     */
+    public function getIgnoreTableParameter() {
+
+        if (!is_array($this->config['ignoreTables']) || count($this->config['ignoreTables']) === 0) {
+            return '';
+        }
+
+        $db = $this->config['database'];
+        $ignoreTables = implode(',', array_map(function($table) use ($db) {
+            return $db.'.'.$table;
+        }, $this->config['ignoreTables']));
+
+        return sprintf('--ignore-table=%s',
+            escapeshellarg($ignoreTables)
         );
     }
 }


### PR DESCRIPTION
Very useful if you have a large table or tables, but it should not be copied to backup file.