### PR TITLE
Update dropbox to api v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Then, you'll need to select the appropriate packages for the adapters that you w
 composer require league/flysystem-aws-s3-v3
 
 # to support dropbox (api v2)
-composer require spatie/flysystem-dropbox
+composer require srmklive/flysystem-dropbox-v2
 
 # to support rackspace
 composer require league/flysystem-rackspace

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ This package is actively being developed and we would like to get feedback to im
 ],
 'dropbox' => [
     'type' => 'Dropbox',
+    'token' => '',
     'key' => '',
     'secret' => '',
     'app' => '',
@@ -176,8 +177,8 @@ Then, you'll need to select the appropriate packages for the adapters that you w
 # to support s3 or google cs
 composer require league/flysystem-aws-s3-v3
 
-# to support dropbox
-composer require league/flysystem-dropbox
+# to support dropbox (api v2)
+composer require spatie/flysystem-dropbox
 
 # to support rackspace
 composer require league/flysystem-rackspace

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "mockery/mockery": "~0.9",
     "satooshi/php-coveralls": "~0.6",
     "league/flysystem-aws-s3-v3": "~1.0",
-    "league/flysystem-dropbox": "~1.0",
+    "spatie/flysystem-dropbox": "~1.0",
     "league/flysystem-rackspace": "~1.0",
     "league/flysystem-sftp": "~1.0",
     "dropbox/dropbox-sdk": "~1.1",
@@ -34,7 +34,7 @@
   },
   "suggest": {
     "league/flysystem-aws-s3-v3": "AwsS3 and GoogleCS adapter support.",
-    "league/flysystem-dropbox": "Dropbox adapter support.",
+    "spatie/flysystem-dropbox": "Dropbox API v2 adapter support.",
     "league/flysystem-rackspace": "Rackspace adapter support.",
     "league/flysystem-sftp": "Sftp adapter support."
   },

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "mockery/mockery": "~0.9",
     "satooshi/php-coveralls": "~0.6",
     "league/flysystem-aws-s3-v3": "~1.0",
-    "spatie/flysystem-dropbox": "~1.0",
+    "srmklive/flysystem-dropbox-v2": "~1.0",
     "league/flysystem-rackspace": "~1.0",
     "league/flysystem-sftp": "~1.0",
     "dropbox/dropbox-sdk": "~1.1",
@@ -34,7 +34,7 @@
   },
   "suggest": {
     "league/flysystem-aws-s3-v3": "AwsS3 and GoogleCS adapter support.",
-    "spatie/flysystem-dropbox": "Dropbox API v2 adapter support.",
+    "srmklive/flysystem-dropbox-v2": "Dropbox API v2 adapter support.",
     "league/flysystem-rackspace": "Rackspace adapter support.",
     "league/flysystem-sftp": "Sftp adapter support."
   },

--- a/spec/Filesystems/DropboxFilesystemSpec.php
+++ b/spec/Filesystems/DropboxFilesystemSpec.php
@@ -23,7 +23,7 @@ class DropboxFilesystemSpec extends ObjectBehavior {
 
     function it_should_provide_an_instance_of_a_dropbox_filesystem() {
         $this->get($this->getConfig())->getAdapter()
-            ->shouldHaveType('League\Flysystem\Dropbox\DropboxAdapter');
+            ->shouldHaveType('Spatie\FlysystemDropbox\DropboxAdapter');
     }
 
     function getConfig() {

--- a/spec/Filesystems/DropboxFilesystemSpec.php
+++ b/spec/Filesystems/DropboxFilesystemSpec.php
@@ -23,7 +23,7 @@ class DropboxFilesystemSpec extends ObjectBehavior {
 
     function it_should_provide_an_instance_of_a_dropbox_filesystem() {
         $this->get($this->getConfig())->getAdapter()
-            ->shouldHaveType('Spatie\FlysystemDropbox\DropboxAdapter');
+            ->shouldHaveType('Srmklive\Dropbox\Adapter\DropboxAdapter');
     }
 
     function getConfig() {

--- a/src/Filesystems/DropboxFilesystem.php
+++ b/src/Filesystems/DropboxFilesystem.php
@@ -1,8 +1,8 @@
 <?php namespace BackupManager\Filesystems;
 
-use League\Flysystem\Dropbox\DropboxAdapter;
-use Dropbox\Client;
 use League\Flysystem\Filesystem as Flysystem;
+use Spatie\Dropbox\Client;
+use Spatie\FlysystemDropbox\DropboxAdapter;
 
 /**
  * Class DropboxFilesystem
@@ -24,7 +24,7 @@ class DropboxFilesystem implements Filesystem {
      * @return Flysystem
      */
     public function get(array $config) {
-        $client = new Client($config['token'], $config['app']);
+        $client = new Client($config['token']);
         return new Flysystem(new DropboxAdapter($client, $config['root']));
     }
 }

--- a/src/Filesystems/DropboxFilesystem.php
+++ b/src/Filesystems/DropboxFilesystem.php
@@ -1,8 +1,8 @@
 <?php namespace BackupManager\Filesystems;
 
 use League\Flysystem\Filesystem as Flysystem;
-use Spatie\Dropbox\Client;
-use Spatie\FlysystemDropbox\DropboxAdapter;
+use Srmklive\Dropbox\Client\DropboxClient;
+use Srmklive\Dropbox\Adapter\DropboxAdapter;
 
 /**
  * Class DropboxFilesystem
@@ -24,7 +24,7 @@ class DropboxFilesystem implements Filesystem {
      * @return Flysystem
      */
     public function get(array $config) {
-        $client = new Client($config['token']);
+        $client = new DropboxClient($config['token']);
         return new Flysystem(new DropboxAdapter($client, $config['root']));
     }
 }


### PR DESCRIPTION
Change the deprecated league/flysystem-dropbox package to
spatie/flysystem-dropbox which uses dropbox api v2.

Since dropbox api v1 will discontinue on June 28th, and league/flysystem-dropbox uses v1 and is discontinued this change is mandatory to keep the dropbox backup working.

More information can be found at the new package developers [blog](https://murze.be/2017/04/dropbox-will-turn-off-v1-of-their-api-soon-its-time-to-update-your-php-application/).