### PR TITLE
add ssl-option for mysql

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ This package is actively being developed and we would like to get feedback to im
     // Example: ['table1', 'table2']
     // http://dev.mysql.com/doc/refman/5.7/en/mysqldump.html#option_mysqldump_ignore-table
     'ignoreTables' => [],
+    // using ssl to connect to your database - active ssl-support:
+    'ssl'=>false,
 ],
 'production' => [
     'type' => 'postgresql',

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ This package is actively being developed and we would like to get feedback to im
     // Example: ['table1', 'table2']
     // http://dev.mysql.com/doc/refman/5.7/en/mysqldump.html#option_mysqldump_ignore-table
     'ignoreTables' => [],
-    // using ssl to connect to your database - active ssl-support:
+    // using ssl to connect to your database - active ssl-support (mysql only):
     'ssl'=>false,
 ],
 'production' => [

--- a/spec/Databases/MysqlDatabaseSpec.php
+++ b/spec/Databases/MysqlDatabaseSpec.php
@@ -34,7 +34,7 @@ class MysqlDatabaseSpec extends ObjectBehavior {
 
     function it_should_generate_a_valid_database_restore_command() {
         $this->configure();
-        $this->getRestoreCommandLine('outputPath')->shouldBe("mysql --host='foo' --port='3306' --user='bar' --password='baz' 'test' -e \"source outputPath\"");
+        $this->getRestoreCommandLine('outputPath')->shouldBe("mysql --host='foo' --port='3306' --user='bar' --password='baz'  'test' -e \"source outputPath\"");
     }
 
     private function configure($db = 'development') {

--- a/src/Databases/MysqlDatabase.php
+++ b/src/Databases/MysqlDatabase.php
@@ -37,6 +37,9 @@ class MysqlDatabase implements Database {
         if (array_key_exists('ignoreTables', $this->config)) {
             $extras[] = $this->getIgnoreTableParameter();
         }
+        if (array_key_exists('ssl', $this->config) && $this->config['ssl'] === true) {
+    		$extras[] = '--ssl';
+    	}
     	$command = 'mysqldump --routines '.implode(' ', $extras).' --host=%s --port=%s --user=%s --password=%s %s > %s';
         return sprintf($command,
             escapeshellarg($this->config['host']),

--- a/src/Databases/MysqlDatabase.php
+++ b/src/Databases/MysqlDatabase.php
@@ -56,7 +56,11 @@ class MysqlDatabase implements Database {
      * @return string
      */
     public function getRestoreCommandLine($inputPath) {
-        return sprintf('mysql --host=%s --port=%s --user=%s --password=%s %s -e "source %s"',
+        $extras = [];
+        if (array_key_exists('ssl', $this->config) && $this->config['ssl'] === true) {
+    		$extras[] = '--ssl';
+    	}
+        return sprintf('mysql --host=%s --port=%s --user=%s --password=%s '.implode(' ', $extras).' %s -e "source %s"',
             escapeshellarg($this->config['host']),
             escapeshellarg($this->config['port']),
             escapeshellarg($this->config['user']),


### PR DESCRIPTION
Connecting to a mysql-database with forced ssl fails in the current version - this pull-request adds the option to activate ssl (which is basically the trigger `--ssl`).