### PR TITLE
Added endpoint to awsS3 to support digital ocean spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,15 @@ It's stable enough, you'll need to understand permissions.
     'name => 's3_backup',
     //'prefix' => 'upload',
 ],
+'doSpaces' => [
+  'type' => 'AwsS3',
+  'key' => '',
+  'secret' => '',
+  'region' => '',
+  'bucket' => '',
+  'root' => '',
+  'endpoint' => '',
+],
 ```
 
 **Backup to / restore from any configured database.**

--- a/config/storage.php
+++ b/config/storage.php
@@ -59,4 +59,13 @@ return [
         'privateKey' => '',
         'root' => '',
     ],
+    'doSpaces' => [
+        'type' => 'AwsS3',
+        'key' => '',
+        'secret' => '',
+        'region' => '',
+        'bucket' => '',
+        'root' => '',
+        'endpoint' => '',
+    ],
 ];

--- a/src/Filesystems/Awss3Filesystem.php
+++ b/src/Filesystems/Awss3Filesystem.php
@@ -30,6 +30,7 @@ class Awss3Filesystem implements Filesystem {
             ],
             'region' => $config['region'],
             'version' => isset($config['version']) ? $config['version'] : 'latest',
+            'endpoint' => isset($config['endpoint']) ? $config['endpoint'] : null,
         ]);
 
         return new Flysystem(new AwsS3Adapter($client, $config['bucket'], $config['root']));


### PR DESCRIPTION
Give support for Digital Ocean Spaces via the s3 driver by enforcing the endpoint instead of auto-discovering back to the amazon domain.