### PR TITLE
Add support for AsyncAws

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
     "superbalist/flysystem-google-storage": "^7.2",
     "aws/aws-sdk-php": "^3.133.20",
     "phpspec/phpspec": "^6.1.1",
-    "friends-of-phpspec/phpspec-code-coverage": "^4.3"
+    "friends-of-phpspec/phpspec-code-coverage": "^4.3",
+    "async-aws/flysystem-s3": "^0.4.2"
   },
   "suggest": {
     "mhetreramesh/flysystem-backblaze": "B2 adapter support.",

--- a/spec/Filesystems/AsyncAwsS3FilesystemSpec.php
+++ b/spec/Filesystems/AsyncAwsS3FilesystemSpec.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace spec\BackupManager\Filesystems;
+
+use PhpSpec\ObjectBehavior;
+
+class AsyncAwsS3FilesystemSpec extends ObjectBehavior {
+
+    function it_is_initializable() {
+        $this->shouldHaveType('BackupManager\Filesystems\AsyncAwsS3Filesystem');
+    }
+
+    function it_should_recognize_its_type_with_case_insensitivity() {
+        foreach (['asyncawss3', 'AsyncAWSS3', 'AsyncAwsS3'] as $type) {
+            $this->handles($type)->shouldBe(true);
+        }
+
+        foreach ([null, 'foo'] as $type) {
+            $this->handles($type)->shouldBe(false);
+        }
+    }
+
+    function it_should_provide_an_instance_of_an_s3_filesystem() {
+        $this->get($this->getConfig())->getAdapter()->shouldHaveType('AsyncAws\Flysystem\S3\S3FilesystemV1');
+    }
+
+    function getConfig() {
+        return [
+            'key'    => 'key',
+            'secret' => 'secret',
+            'region' => 'us-east-1',
+            'bucket' => 'bucket',
+            'root'   => 'prefix',
+        ];
+    }
+}

--- a/src/Filesystems/AsyncAwsS3Filesystem.php
+++ b/src/Filesystems/AsyncAwsS3Filesystem.php
@@ -1,0 +1,49 @@
+<?php namespace BackupManager\Filesystems;
+
+use AsyncAws\Flysystem\S3\S3FilesystemV1;
+use AsyncAws\S3\S3Client;
+use League\Flysystem\Filesystem as Flysystem;
+
+/**
+ * @package BackupManager\Filesystems
+ */
+class AsyncAwsS3Filesystem implements Filesystem
+{
+    /**
+     * @param $type
+     * @return bool
+     */
+    public function handles($type)
+    {
+        return strtolower($type) == 'asyncawss3';
+    }
+
+    /**
+     * @param array $config
+     * @return Flysystem
+     */
+    public function get(array $config)
+    {
+        $clientConfig = [
+            'pathStyleEndpoint' => isset($config['use_path_style_endpoint']) ? $config['use_path_style_endpoint'] : false
+        ];
+
+        if (null !== $config['key']) {
+            $clientConfig['accessKeyId'] = $config['key'];
+        }
+
+        if (null !== $config['secret']) {
+            $clientConfig['accessKeySecret'] = $config['secret'];
+        }
+
+        if (null !== $config['region']) {
+            $clientConfig['region'] = $config['region'];
+        }
+
+        if (null !== $config['endpoint']) {
+            $clientConfig['endpoint'] = $config['endpoint'];
+        }
+
+        return new Flysystem(new S3FilesystemV1(new S3Client($clientConfig), $config['bucket'], $config['root']));
+    }
+}


### PR DESCRIPTION
This Filesystem is very similar to the official AWS SDK but it does not require you to download 20Mb of dependencies. 

`async-aws/flysystem-s3` supports both Flysystem 1 and 2. It will be tagged with a stable release when Flysystem 2 is released. 