### PR TITLE
Add PHP 8.0 support to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     }
   ],
   "require": {
-    "php":  "^7.3 || ^7.4",
+    "php":  "^7.3 || ^8.0",
     "symfony/process": "^4.4 || ^5.0",
     "league/flysystem": "^1.0.64"
   },

--- a/composer.json
+++ b/composer.json
@@ -14,9 +14,9 @@
     }
   ],
   "require": {
-    "php":  "^7.3 || ^8.0",
-    "symfony/process": "^4.4 || ^5.0",
-    "league/flysystem": "^1.0.64"
+    "php":  "^7.4 || ^8.0",
+    "symfony/process": "^4.4 || ^5.0 || ^6.0",
+    "league/flysystem": "^1.0.64 || ^2.0 || ^3.0"
   },
   "require-dev": {
     "league/flysystem-aws-s3-v3": "^1.0.24",


### PR DESCRIPTION
Nothing tricky here - just changing the version constraint to permit installing in PHP 8.0 projects.