### PR TITLE
Fix local adapter

### DIFF
--- a/src/Filesystems/LocalFilesystem.php
+++ b/src/Filesystems/LocalFilesystem.php
@@ -1,6 +1,6 @@
 <?php namespace BackupManager\Filesystems;
 
-use League\Flysystem\Adapter\Local;
+use League\Flysystem\Local\LocalFilesystemAdapter;
 use League\Flysystem\Filesystem as Flysystem;
 
 /**
@@ -25,6 +25,6 @@ class LocalFilesystem implements Filesystem
      */
     public function get(array $config)
     {
-        return new Flysystem(new Local($config['root']));
+        return new Flysystem(new LocalFilesystemAdapter($config['root']));
     }
 }


### PR DESCRIPTION
Flysystem got upgraded to 3.1, but it seems compatibility haven't been checked for the basic local adapter. XD
NB: I also updated some other flysystem additional adapters, otherwise some classes were missing.
       Please update if not useful